### PR TITLE
Fix LanesView not hidden when it should be hidden

### DIFF
--- a/MapboxNavigation/LanesView.swift
+++ b/MapboxNavigation/LanesView.swift
@@ -103,12 +103,7 @@ open class LanesView: UIView {
     }
     
     public func hide() {
-        let isShowing = if let parent = superview?.superview as? NavigationView {
-            parent.showing
-        } else {
-            false
-        }
-        guard isHidden == false || isShowing else { return }
+        guard isHidden == false else { return }
         UIView.defaultAnimation(0.3, animations: {
             self.isHidden = true
         }, completion: nil)

--- a/MapboxNavigation/LanesView.swift
+++ b/MapboxNavigation/LanesView.swift
@@ -103,7 +103,7 @@ open class LanesView: UIView {
     }
     
     public func hide() {
-        let isShowing = if let parent = superview as? NavigationView {
+        let isShowing = if let parent = superview?.superview as? NavigationView {
             parent.showing
         } else {
             false

--- a/MapboxNavigation/LanesView.swift
+++ b/MapboxNavigation/LanesView.swift
@@ -103,7 +103,12 @@ open class LanesView: UIView {
     }
     
     public func hide() {
-        guard isHidden == false else { return }
+        let isShowing = if let parent = superview as? NavigationView {
+            parent.showing
+        } else {
+            false
+        }
+        guard isHidden == false || isShowing else { return }
         UIView.defaultAnimation(0.3, animations: {
             self.isHidden = true
         }, completion: nil)

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -178,6 +178,7 @@ open class NavigationView: UIView {
         self.wayNameView.text = "Street Label"
     }
 	
+    var showing = false
     func showUI(animated: Bool = true) {
         let views: [UIView] = [
             self.instructionsBannerContentView,
@@ -196,11 +197,13 @@ open class NavigationView: UIView {
             self.currentSpeedView.bottomAnchor.constraint(equalTo: self.bottomBannerContentView.topAnchor, constant: -20)
         ])
 		
+        self.showing = true
         UIView.animate(withDuration: animated ? CATransaction.animationDuration() : 0) {
             views.forEach { $0.alpha = 1 }
         } completion: { _ in
             views.forEach { $0.isHidden = false }
             self.bottomBannerView.traitCollectionDidChange(self.traitCollection)
+            self.showing = false
         }
     }
 	

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -1,9 +1,6 @@
 import MapboxDirections
 import MapLibre
-import OSLog
 import UIKit
-
-let myLogger = OSLog(subsystem: "MapLibreNavigation", category: .pointsOfInterest)
 
 protocol NavigationViewDelegate: NavigationMapViewDelegate, MLNMapViewDelegate, StatusViewDelegate, InstructionsBannerViewDelegate, NavigationMapViewCourseTrackingDelegate, VisualInstructionDelegate {
     func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton)

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -1,7 +1,7 @@
 import MapboxDirections
 import MapLibre
-import UIKit
 import OSLog
+import UIKit
 
 let myLogger = OSLog(subsystem: "MapLibreNavigation", category: .pointsOfInterest)
 
@@ -182,7 +182,6 @@ open class NavigationView: UIView {
     }
 	
     func showUI(animated: Bool = true) {
-        os_signpost(.begin, log: myLogger, name: "showUI")
         let views: [UIView] = [
             self.instructionsBannerContentView,
             self.bottomBannerContentView,
@@ -198,15 +197,12 @@ open class NavigationView: UIView {
             self.currentSpeedView.leadingAnchor.constraint(equalTo: self.mapView.leadingAnchor, constant: 20),
             self.currentSpeedView.bottomAnchor.constraint(equalTo: self.bottomBannerContentView.topAnchor, constant: -20)
         ])
-        os_signpost(.event, log: myLogger, name: "finish constraints")
 		
-        lanesView.show()
         UIView.animate(withDuration: animated ? CATransaction.animationDuration() : 0) {
             views.forEach { $0.alpha = 1 }
         } completion: { _ in
             views.forEach { $0.isHidden = false }
             self.bottomBannerView.traitCollectionDidChange(self.traitCollection)
-            os_signpost(.end, log: myLogger, name: "showUI")
         }
     }
 	
@@ -222,7 +218,6 @@ open class NavigationView: UIView {
         NSLayoutConstraint.deactivate(self.bannerShowConstraints)
         NSLayoutConstraint.activate(self.bannerHideConstraints)
 		
-        lanesView.hide()
         UIView.animate(withDuration: animated ? CATransaction.animationDuration() : 0) {
             views.forEach { $0.alpha = 0 }
         } completion: { _ in

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -1,6 +1,9 @@
 import MapboxDirections
 import MapLibre
 import UIKit
+import OSLog
+
+let myLogger = OSLog(subsystem: "MapLibreNavigation", category: .pointsOfInterest)
 
 protocol NavigationViewDelegate: NavigationMapViewDelegate, MLNMapViewDelegate, StatusViewDelegate, InstructionsBannerViewDelegate, NavigationMapViewCourseTrackingDelegate, VisualInstructionDelegate {
     func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton)
@@ -178,11 +181,10 @@ open class NavigationView: UIView {
         self.wayNameView.text = "Street Label"
     }
 	
-    var showing = false
     func showUI(animated: Bool = true) {
+        os_signpost(.begin, log: myLogger, name: "showUI")
         let views: [UIView] = [
             self.instructionsBannerContentView,
-            self.lanesView,
             self.bottomBannerContentView,
             self.floatingStackView,
             self.currentSpeedView
@@ -196,21 +198,21 @@ open class NavigationView: UIView {
             self.currentSpeedView.leadingAnchor.constraint(equalTo: self.mapView.leadingAnchor, constant: 20),
             self.currentSpeedView.bottomAnchor.constraint(equalTo: self.bottomBannerContentView.topAnchor, constant: -20)
         ])
+        os_signpost(.event, log: myLogger, name: "finish constraints")
 		
-        self.showing = true
+        lanesView.show()
         UIView.animate(withDuration: animated ? CATransaction.animationDuration() : 0) {
             views.forEach { $0.alpha = 1 }
         } completion: { _ in
             views.forEach { $0.isHidden = false }
             self.bottomBannerView.traitCollectionDidChange(self.traitCollection)
-            self.showing = false
+            os_signpost(.end, log: myLogger, name: "showUI")
         }
     }
 	
     func hideUI(animated: Bool = true) {
         let views: [UIView] = [
             self.instructionsBannerContentView,
-            self.lanesView,
             self.bottomBannerContentView,
             self.floatingStackView,
             self.resumeButton,
@@ -220,6 +222,7 @@ open class NavigationView: UIView {
         NSLayoutConstraint.deactivate(self.bannerShowConstraints)
         NSLayoutConstraint.activate(self.bannerHideConstraints)
 		
+        lanesView.hide()
         UIView.animate(withDuration: animated ? CATransaction.animationDuration() : 0) {
             views.forEach { $0.alpha = 0 }
         } completion: { _ in


### PR DESCRIPTION
### Description

Hide LaneView when Navigation is starting but make sure it shows up if the route contains lane information

### Tasks

- [x] don't hide LanesView by adjusting alpha value
- [x] let `update(for visualInstruction: VisualInstructionBanner?)` handle show & hide

### Infos for Reviewer

The underlying issue was that we animated the alpha value of the LanesView and therefore didn't show up if there was a lane instruction.

I've used a route in Berlin using Mapbox API to obtain a route which I know contains lane information. Please note that our map style doesn't contain map data in this region, thats why it's empty. The route works regardless.

![Bildschirmaufnahme (Simulator)](https://github.com/user-attachments/assets/d00dae8c-8981-4ea4-8f0f-592acfa260b3)
